### PR TITLE
[MT-1671] - Log Event fallback to payload when parameters are not mapped

### DIFF
--- a/appsflyer/build.gradle
+++ b/appsflyer/build.gradle
@@ -29,13 +29,12 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     api 'com.tealium:remotecommands:1.0.1'
     api "com.appsflyer:af-android-sdk:$appsflyer_version"
     implementation 'com.android.installreferrer:installreferrer:2.2'
 
     testImplementation 'junit:junit:4.12'
-    testImplementation "org.robolectric:robolectric:4.2"
+    testImplementation "org.robolectric:robolectric:4.13"
     testImplementation "io.mockk:mockk:$mockk_version"
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'androidx.test:runner:1.2.0'

--- a/appsflyer/src/main/java/com/tealium/remotecommands/appsflyer/AppsFlyerConstants.kt
+++ b/appsflyer/src/main/java/com/tealium/remotecommands/appsflyer/AppsFlyerConstants.kt
@@ -22,6 +22,7 @@ object Commands {
 
 object StandardEvents {
     const val EVENT_PARAMETERS = "event_parameters"
+    const val EVENT_PARAMETERS_SHORT = "event"
     val eventNames = mapOf(
         "levelachieved" to AFInAppEventType.LEVEL_ACHIEVED,
         "addpaymentinfo" to AFInAppEventType.ADD_PAYMENT_INFO,

--- a/appsflyer/src/test/java/com/tealium/remotecommands/appsflyer/AppsFlyerRemoteCommandTest.kt
+++ b/appsflyer/src/test/java/com/tealium/remotecommands/appsflyer/AppsFlyerRemoteCommandTest.kt
@@ -19,7 +19,7 @@ class AppsFlyerRemoteCommandTest {
     @MockK
     lateinit var mockApplication: Application
 
-    @MockK
+    @MockK(relaxed = true)
     lateinit var mockAppsFlyerInstance: AppsFlyerCommand
 
     lateinit var appsFlyerRemoteCommand: AppsFlyerRemoteCommand
@@ -53,10 +53,6 @@ class AppsFlyerRemoteCommandTest {
         payload.put(Location.LONGITUDE, 11.0)
         payload.put(COMMAND_NAME_KEY, Commands.TRACK_LOCATION)
 
-        every {
-            mockAppsFlyerInstance.trackLocation(any(), any())
-        } just Runs
-
         appsFlyerRemoteCommand.parseCommands(arrayOf(Commands.TRACK_LOCATION), payload)
 
         verify {
@@ -73,10 +69,6 @@ class AppsFlyerRemoteCommandTest {
         payload.put(Host.HOST_PREFIX, "")
         payload.put(COMMAND_NAME_KEY, Commands.SET_HOST)
         appsFlyerRemoteCommand.parseCommands(arrayOf(Commands.SET_HOST), payload)
-
-        every {
-            mockAppsFlyerInstance.setHost(any(), any())
-        } just Runs
 
         verify {
             mockAppsFlyerInstance.setHost("www.test123.com")
@@ -97,10 +89,6 @@ class AppsFlyerRemoteCommandTest {
         payload.put(COMMAND_NAME_KEY, Commands.SET_USER_EMAILS)
 
         appsFlyerRemoteCommand.parseCommands(arrayOf(Commands.SET_USER_EMAILS), payload)
-
-        every {
-            mockAppsFlyerInstance.setUserEmails(any())
-        } just Runs
 
         verify {
             mockAppsFlyerInstance.setUserEmails(
@@ -123,10 +111,6 @@ class AppsFlyerRemoteCommandTest {
 
         appsFlyerRemoteCommand.parseCommands(arrayOf(Commands.SET_CURRENCY_CODE), payload)
 
-        every {
-            mockAppsFlyerInstance.setCurrencyCode(any())
-        } just Runs
-
         verify {
             mockAppsFlyerInstance.setCurrencyCode("USD")
         }
@@ -142,10 +126,6 @@ class AppsFlyerRemoteCommandTest {
 
         appsFlyerRemoteCommand.parseCommands(arrayOf(Commands.SET_CUSTOMER_ID), payload)
 
-        every {
-            mockAppsFlyerInstance.setCustomerId(any())
-        } just Runs
-
         verify {
             mockAppsFlyerInstance.setCustomerId("1234")
         }
@@ -160,10 +140,6 @@ class AppsFlyerRemoteCommandTest {
         payload.put(COMMAND_NAME_KEY, Commands.DISABLE_DEVICE_TRACKING)
 
         appsFlyerRemoteCommand.parseCommands(arrayOf(Commands.DISABLE_DEVICE_TRACKING), payload)
-
-        every {
-            mockAppsFlyerInstance.disableDeviceTracking(any())
-        } just Runs
 
         verify {
             mockAppsFlyerInstance.disableDeviceTracking(true)
@@ -186,10 +162,6 @@ class AppsFlyerRemoteCommandTest {
 
         appsFlyerRemoteCommand.parseCommands(arrayOf(Commands.RESOLVE_DEEPLINK_URLS), payload)
 
-        every {
-            mockAppsFlyerInstance.resolveDeepLinkUrls(any())
-        } just Runs
-
         verify {
             mockAppsFlyerInstance.resolveDeepLinkUrls(listOf("val1", "val2", "val3"))
         }
@@ -204,10 +176,6 @@ class AppsFlyerRemoteCommandTest {
         payload.put(COMMAND_NAME_KEY, Commands.STOP_TRACKING)
 
         appsFlyerRemoteCommand.parseCommands(arrayOf(Commands.STOP_TRACKING), payload)
-
-        every {
-            mockAppsFlyerInstance.stopTracking(any())
-        } just Runs
 
         verify {
             mockAppsFlyerInstance.stopTracking(true)

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.6.20'
+    ext.kotlin_version = '1.8.22'
     ext.mockk_version = '1.12.0'
-    ext.tealium_appsflyer_version = '1.3.0'
+    ext.tealium_appsflyer_version = '1.4.0'
     ext.appsflyer_version = "[6.5,7)"
 
     repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,6 @@ org.gradle.jvmargs=-Xmx1536m
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
+#android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official


### PR DESCRIPTION
 - Support for shorthand `event` mapping for event parameters
 - Falls back to the main payload (filtered) for `logEvent` parameters, when `event_parameters` and `event` are absent from the payload, in line with the iOS implementation
 - updates Kotlin build version to 1.8